### PR TITLE
Fixed an subtle issue causing files with certain Unicode characters not be found from a ZipFile

### DIFF
--- a/Objective-Zip/FileInZipInfo.m
+++ b/Objective-Zip/FileInZipInfo.m
@@ -38,22 +38,16 @@
 
 - (id) initWithName:(NSString *)name length:(NSUInteger)length level:(ZipCompressionLevel)level crypted:(BOOL)crypted size:(NSUInteger)size date:(NSDate *)date crc32:(NSUInteger)crc32 {
 	if ((self = [super init])) {
-		_name= [name retain];
+		_name= [name copy];
 		_length= length;
 		_level= level;
 		_crypted= crypted;
 		_size= size;
-		_date= [date retain];
+		_date= date;
 		_crc32= crc32;
 	}
 	
 	return self;
-}
-
-- (void) dealloc {
-	[_date release];
-	[_name release];
-	[super dealloc];
 }
 
 @synthesize name= _name;

--- a/Objective-Zip/ZipFile.h
+++ b/Objective-Zip/ZipFile.h
@@ -73,7 +73,7 @@ typedef enum {
 - (NSUInteger) numFilesInZip;
 - (NSArray *) listFileInZipInfos;
 
-- (void) goToFirstFileInZip;
+- (BOOL) goToFirstFileInZip;
 - (BOOL) goToNextFileInZip;
 - (BOOL) locateFileInZip:(NSString *)fileNameInZip;
 

--- a/Objective-Zip/ZipFile.h
+++ b/Objective-Zip/ZipFile.h
@@ -77,7 +77,7 @@ typedef enum {
 - (BOOL) goToNextFileInZip;
 - (BOOL) locateFileInZip:(NSString *)fileNameInZip;
 
-- (FileInZipInfo *) getCurrentFileInZipInfo;
+- (FileInZipInfo *) currentFileInZipInfo;
 
 - (ZipReadStream *) readCurrentFileInZip;
 - (ZipReadStream *) readCurrentFileInZipWithPassword:(NSString *)password;

--- a/Objective-Zip/ZipFile.m
+++ b/Objective-Zip/ZipFile.m
@@ -251,17 +251,21 @@
 	return files;
 }
 
-- (void) goToFirstFileInZip {
+- (BOOL)goToFirstFileInZip
+{
 	if (_mode != ZipFileModeUnzip) {
 		NSString *reason= [NSString stringWithFormat:@"Operation not permitted without Unzip mode"];
 		@throw [[[ZipException alloc] initWithReason:reason] autorelease];
+        return NO;
 	}
 	
 	int err= unzGoToFirstFile(_unzFile);
-	if (err != UNZ_OK) {
-		NSString *reason= [NSString stringWithFormat:@"Error in going to first file in zip in '%@'", _fileName];
-		@throw [[[ZipException alloc] initWithError:err reason:reason] autorelease];
-	}
+	if (err != UNZ_OK)
+    {
+        NSLog(@"Error in going to first file in zip in '%@'", _fileName);
+    }
+    
+    return YES;
 }
 
 - (BOOL) goToNextFileInZip {

--- a/Objective-Zip/ZipFile.m
+++ b/Objective-Zip/ZipFile.m
@@ -291,7 +291,7 @@
 	
 	//int err= unzLocateFile(_unzFile, [fileNameInZip cStringUsingEncoding:NSUTF8StringEncoding], 1);
 	
-    NSArray* info = [contents objectForKey:fileNameInZip];
+    NSArray* info = [contents objectForKey:[fileNameInZip decomposedStringWithCanonicalMapping]];
     
     if (!info) return NO;
     
@@ -327,8 +327,8 @@
 		@throw [[ZipException alloc] initWithError:err reason:reason];
 	}
 	
-	NSString *name= [NSString stringWithCString:filename_inzip encoding:NSUTF8StringEncoding];
-	
+	NSString *name= [[NSString stringWithUTF8String:filename_inzip] decomposedStringWithCanonicalMapping];
+    
 	ZipCompressionLevel level= ZipCompressionLevelNone;
 	if (file_info.compression_method != 0) {
 		switch ((file_info.flag & 0x6) / 2) {

--- a/Objective-Zip/ZipFile.m
+++ b/Objective-Zip/ZipFile.m
@@ -64,7 +64,7 @@
                     FileInZipInfo* info = [self currentFileInZipInfo];
                     unz_file_pos pos;
                     int err = unzGetFilePos(_unzFile, &pos);
-                    if (err == UNZ_OK) {
+                    if (err == UNZ_OK && info.name) {
                         [dic setObject:[NSArray arrayWithObjects:
                                         [NSNumber numberWithLong:pos.pos_in_zip_directory],
                                         [NSNumber numberWithLong:pos.num_of_file],

--- a/Objective-Zip/ZipFile.m
+++ b/Objective-Zip/ZipFile.m
@@ -44,15 +44,16 @@
 
 - (id) initWithFileName:(NSString *)fileName mode:(ZipFileMode)mode {
 	if ((self= [super init])) {
-		_fileName= [fileName retain];
+		_fileName= [fileName copy];
 		_mode= mode;
 		
 		switch (mode) {
 			case ZipFileModeUnzip:
+            {
 				_unzFile= unzOpen([_fileName cStringUsingEncoding:NSUTF8StringEncoding]);
 				if (_unzFile == NULL) {
 					NSString *reason= [NSString stringWithFormat:@"Can't open '%@'", _fileName];
-					@throw [[[ZipException alloc] initWithReason:reason] autorelease];
+					@throw [[ZipException alloc] initWithReason:reason];
 				}
                 
                 unzGoToFirstFile(_unzFile);
@@ -71,29 +72,31 @@
                     }
                 } while (unzGoToNextFile (_unzFile) != UNZ_END_OF_LIST_OF_FILE);
                 
-                contents = [dic retain];
+                contents = dic;
                 
 				break;
-				
+            }
 			case ZipFileModeCreate:
+            {
 				_zipFile= zipOpen([_fileName cStringUsingEncoding:NSUTF8StringEncoding], APPEND_STATUS_CREATE);
 				if (_zipFile == NULL) {
 					NSString *reason= [NSString stringWithFormat:@"Can't open '%@'", _fileName];
-					@throw [[[ZipException alloc] initWithReason:reason] autorelease];
+					@throw [[ZipException alloc] initWithReason:reason];
 				}
 				break;
-				
+            }
 			case ZipFileModeAppend:
+            {
 				_zipFile= zipOpen([_fileName cStringUsingEncoding:NSUTF8StringEncoding], APPEND_STATUS_ADDINZIP);
 				if (_zipFile == NULL) {
 					NSString *reason= [NSString stringWithFormat:@"Can't open '%@'", _fileName];
-					@throw [[[ZipException alloc] initWithReason:reason] autorelease];
+					@throw [[ZipException alloc] initWithReason:reason];
 				}
 				break;
-				
+            }
 			default: {
 				NSString *reason= [NSString stringWithFormat:@"Unknown mode %d", _mode];
-				@throw [[[ZipException alloc] initWithReason:reason] autorelease];
+				@throw [[ZipException alloc] initWithReason:reason];
 			}
 		}
 	}
@@ -101,16 +104,10 @@
 	return self;
 }
 
-- (void) dealloc {
-	[_fileName release];
-    [contents release];
-	[super dealloc];
-}
-
 - (ZipWriteStream *) writeFileInZipWithName:(NSString *)fileNameInZip compressionLevel:(ZipCompressionLevel)compressionLevel {
 	if (_mode == ZipFileModeUnzip) {
 		NSString *reason= [NSString stringWithFormat:@"Operation not permitted with Unzip mode"];
-		@throw [[[ZipException alloc] initWithReason:reason] autorelease];
+		@throw [[ZipException alloc] initWithReason:reason];
 	}
 	
 	NSDate *now= [NSDate date];
@@ -138,16 +135,16 @@
 								  NULL, 0);
 	if (err != ZIP_OK) {
 		NSString *reason= [NSString stringWithFormat:@"Error in opening '%@' in zipfile", fileNameInZip];
-		@throw [[[ZipException alloc] initWithError:err reason:reason] autorelease];
+		@throw [[ZipException alloc] initWithError:err reason:reason];
 	}
 	
-	return [[[ZipWriteStream alloc] initWithZipFileStruct:_zipFile fileNameInZip:fileNameInZip] autorelease];
+	return [[ZipWriteStream alloc] initWithZipFileStruct:_zipFile fileNameInZip:fileNameInZip];
 }
 
 - (ZipWriteStream *) writeFileInZipWithName:(NSString *)fileNameInZip fileDate:(NSDate *)fileDate compressionLevel:(ZipCompressionLevel)compressionLevel {
 	if (_mode == ZipFileModeUnzip) {
 		NSString *reason= [NSString stringWithFormat:@"Operation not permitted with Unzip mode"];
-		@throw [[[ZipException alloc] initWithReason:reason] autorelease];
+		@throw [[ZipException alloc] initWithReason:reason];
 	}
 	
 	NSCalendar *calendar= [NSCalendar currentCalendar];
@@ -174,16 +171,16 @@
 								  NULL, 0);
 	if (err != ZIP_OK) {
 		NSString *reason= [NSString stringWithFormat:@"Error in opening '%@' in zipfile", fileNameInZip];
-		@throw [[[ZipException alloc] initWithError:err reason:reason] autorelease];
+		@throw [[ZipException alloc] initWithError:err reason:reason];
 	}
 	
-	return [[[ZipWriteStream alloc] initWithZipFileStruct:_zipFile fileNameInZip:fileNameInZip] autorelease];
+	return [[ZipWriteStream alloc] initWithZipFileStruct:_zipFile fileNameInZip:fileNameInZip];
 }
 
 - (ZipWriteStream *) writeFileInZipWithName:(NSString *)fileNameInZip fileDate:(NSDate *)fileDate compressionLevel:(ZipCompressionLevel)compressionLevel password:(NSString *)password crc32:(NSUInteger)crc32 {
 	if (_mode == ZipFileModeUnzip) {
 		NSString *reason= [NSString stringWithFormat:@"Operation not permitted with Unzip mode"];
-		@throw [[[ZipException alloc] initWithReason:reason] autorelease];
+		@throw [[ZipException alloc] initWithReason:reason];
 	}
 	
 	NSCalendar *calendar= [NSCalendar currentCalendar];
@@ -210,23 +207,23 @@
 								  [password cStringUsingEncoding:NSUTF8StringEncoding], crc32);
 	if (err != ZIP_OK) {
 		NSString *reason= [NSString stringWithFormat:@"Error in opening '%@' in zipfile", fileNameInZip];
-		@throw [[[ZipException alloc] initWithError:err reason:reason] autorelease];
+		@throw [[ZipException alloc] initWithError:err reason:reason];
 	}
 	
-	return [[[ZipWriteStream alloc] initWithZipFileStruct:_zipFile fileNameInZip:fileNameInZip] autorelease];
+	return [[ZipWriteStream alloc] initWithZipFileStruct:_zipFile fileNameInZip:fileNameInZip];
 }
 
 - (NSUInteger) numFilesInZip {
 	if (_mode != ZipFileModeUnzip) {
 		NSString *reason= [NSString stringWithFormat:@"Operation not permitted without Unzip mode"];
-		@throw [[[ZipException alloc] initWithReason:reason] autorelease];
+		@throw [[ZipException alloc] initWithReason:reason];
 	}
 	
 	unz_global_info gi;
 	int err= unzGetGlobalInfo(_unzFile, &gi);
 	if (err != UNZ_OK) {
 		NSString *reason= [NSString stringWithFormat:@"Error in getting global info in '%@'", _fileName];
-		@throw [[[ZipException alloc] initWithError:err reason:reason] autorelease];
+		@throw [[ZipException alloc] initWithError:err reason:reason];
 	}
 	
 	return gi.number_entry;
@@ -235,9 +232,9 @@
 - (NSArray *) listFileInZipInfos {
 	int num= (uInt)[self numFilesInZip];
 	if (num < 1)
-		return [[[NSArray alloc] init] autorelease];
+		return [[NSArray alloc] init];
 	
-	NSMutableArray *files= [[[NSMutableArray alloc] initWithCapacity:num] autorelease];
+	NSMutableArray *files= [[NSMutableArray alloc] initWithCapacity:num];
 
 	[self goToFirstFileInZip];
 	for (int i= 0; i < num; i++) {
@@ -255,7 +252,7 @@
 {
 	if (_mode != ZipFileModeUnzip) {
 		NSString *reason= [NSString stringWithFormat:@"Operation not permitted without Unzip mode"];
-		@throw [[[ZipException alloc] initWithReason:reason] autorelease];
+		@throw [[ZipException alloc] initWithReason:reason];
         return NO;
 	}
 	
@@ -271,7 +268,7 @@
 - (BOOL) goToNextFileInZip {
 	if (_mode != ZipFileModeUnzip) {
 		NSString *reason= [NSString stringWithFormat:@"Operation not permitted without Unzip mode"];
-		@throw [[[ZipException alloc] initWithReason:reason] autorelease];
+		@throw [[ZipException alloc] initWithReason:reason];
 	}
 	
 	int err= unzGoToNextFile(_unzFile);
@@ -280,7 +277,7 @@
 
 	if (err != UNZ_OK) {
 		NSString *reason= [NSString stringWithFormat:@"Error in going to next file in zip in '%@'", _fileName];
-		@throw [[[ZipException alloc] initWithError:err reason:reason] autorelease];
+		@throw [[ZipException alloc] initWithError:err reason:reason];
 	}
 	
 	return YES;
@@ -289,7 +286,7 @@
 - (BOOL) locateFileInZip:(NSString *)fileNameInZip {
 	if (_mode != ZipFileModeUnzip) {
 		NSString *reason= [NSString stringWithFormat:@"Operation not permitted without Unzip mode"];
-		@throw [[[ZipException alloc] initWithReason:reason] autorelease];
+		@throw [[ZipException alloc] initWithReason:reason];
 	}
 	
 	//int err= unzLocateFile(_unzFile, [fileNameInZip cStringUsingEncoding:NSUTF8StringEncoding], 1);
@@ -309,7 +306,7 @@
 
 	if (err != UNZ_OK) {
 		NSString *reason= [NSString stringWithFormat:@"Error in going to next file in zip in '%@'", _fileName];
-		@throw [[[ZipException alloc] initWithError:err reason:reason] autorelease];
+		@throw [[ZipException alloc] initWithError:err reason:reason];
 	}
 	
 	return YES;
@@ -318,7 +315,7 @@
 - (FileInZipInfo *)currentFileInZipInfo {
 	if (_mode != ZipFileModeUnzip) {
 		NSString *reason= [NSString stringWithFormat:@"Operation not permitted without Unzip mode"];
-		@throw [[[ZipException alloc] initWithReason:reason] autorelease];
+		@throw [[ZipException alloc] initWithReason:reason];
 	}
 
 	char filename_inzip[FILE_IN_ZIP_MAX_NAME_LENGTH];
@@ -327,7 +324,7 @@
 	int err= unzGetCurrentFileInfo(_unzFile, &file_info, filename_inzip, sizeof(filename_inzip), NULL, 0, NULL, 0);
 	if (err != UNZ_OK) {
 		NSString *reason= [NSString stringWithFormat:@"Error in getting current file info in '%@'", _fileName];
-		@throw [[[ZipException alloc] initWithError:err reason:reason] autorelease];
+		@throw [[ZipException alloc] initWithError:err reason:reason];
 	}
 	
 	NSString *name= [NSString stringWithCString:filename_inzip encoding:NSUTF8StringEncoding];
@@ -351,7 +348,7 @@
 	
 	BOOL crypted= ((file_info.flag & 1) != 0);
 	
-	NSDateComponents *components= [[[NSDateComponents alloc] init] autorelease];
+	NSDateComponents *components= [[NSDateComponents alloc] init];
 	[components setDay:file_info.tmu_date.tm_mday];
 	[components setMonth:file_info.tmu_date.tm_mon +1];
 	[components setYear:file_info.tmu_date.tm_year];
@@ -362,13 +359,13 @@
 	NSDate *date= [calendar dateFromComponents:components];
 	
 	FileInZipInfo *info= [[FileInZipInfo alloc] initWithName:name length:file_info.uncompressed_size level:level crypted:crypted size:file_info.compressed_size date:date crc32:file_info.crc];
-	return [info autorelease];
+	return info;
 }
 
 - (ZipReadStream *) readCurrentFileInZip {
 	if (_mode != ZipFileModeUnzip) {
 		NSString *reason= [NSString stringWithFormat:@"Operation not permitted without Unzip mode"];
-		@throw [[[ZipException alloc] initWithReason:reason] autorelease];
+		@throw [[ZipException alloc] initWithReason:reason];
 	}
 
 	char filename_inzip[FILE_IN_ZIP_MAX_NAME_LENGTH];
@@ -377,7 +374,7 @@
 	int err= unzGetCurrentFileInfo(_unzFile, &file_info, filename_inzip, sizeof(filename_inzip), NULL, 0, NULL, 0);
 	if (err != UNZ_OK) {
 		NSString *reason= [NSString stringWithFormat:@"Error in getting current file info in '%@'", _fileName];
-		@throw [[[ZipException alloc] initWithError:err reason:reason] autorelease];
+		@throw [[ZipException alloc] initWithError:err reason:reason];
 	}
 	
 	NSString *fileNameInZip= [NSString stringWithCString:filename_inzip encoding:NSUTF8StringEncoding];
@@ -385,16 +382,16 @@
 	err= unzOpenCurrentFilePassword(_unzFile, NULL);
 	if (err != UNZ_OK) {
 		NSString *reason= [NSString stringWithFormat:@"Error in opening current file in '%@'", _fileName];
-		@throw [[[ZipException alloc] initWithError:err reason:reason] autorelease];
+		@throw [[ZipException alloc] initWithError:err reason:reason];
 	}
 	
-	return [[[ZipReadStream alloc] initWithUnzFileStruct:_unzFile fileNameInZip:fileNameInZip] autorelease];
+	return [[ZipReadStream alloc] initWithUnzFileStruct:_unzFile fileNameInZip:fileNameInZip];
 }
 
 - (ZipReadStream *) readCurrentFileInZipWithPassword:(NSString *)password {
 	if (_mode != ZipFileModeUnzip) {
 		NSString *reason= [NSString stringWithFormat:@"Operation not permitted without Unzip mode"];
-		@throw [[[ZipException alloc] initWithReason:reason] autorelease];
+		@throw [[ZipException alloc] initWithReason:reason];
 	}
 	
 	char filename_inzip[FILE_IN_ZIP_MAX_NAME_LENGTH];
@@ -403,7 +400,7 @@
 	int err= unzGetCurrentFileInfo(_unzFile, &file_info, filename_inzip, sizeof(filename_inzip), NULL, 0, NULL, 0);
 	if (err != UNZ_OK) {
 		NSString *reason= [NSString stringWithFormat:@"Error in getting current file info in '%@'", _fileName];
-		@throw [[[ZipException alloc] initWithError:err reason:reason] autorelease];
+		@throw [[ZipException alloc] initWithError:err reason:reason];
 	}
 	
 	NSString *fileNameInZip= [NSString stringWithCString:filename_inzip encoding:NSUTF8StringEncoding];
@@ -411,10 +408,10 @@
 	err= unzOpenCurrentFilePassword(_unzFile, [password cStringUsingEncoding:NSUTF8StringEncoding]);
 	if (err != UNZ_OK) {
 		NSString *reason= [NSString stringWithFormat:@"Error in opening current file in '%@'", _fileName];
-		@throw [[[ZipException alloc] initWithError:err reason:reason] autorelease];
+		@throw [[ZipException alloc] initWithError:err reason:reason];
 	}
 	
-	return [[[ZipReadStream alloc] initWithUnzFileStruct:_unzFile fileNameInZip:fileNameInZip] autorelease];
+	return [[ZipReadStream alloc] initWithUnzFileStruct:_unzFile fileNameInZip:fileNameInZip];
 }
 
 - (void) close {
@@ -423,7 +420,7 @@
 			int err= unzClose(_unzFile);
 			if (err != UNZ_OK) {
 				NSString *reason= [NSString stringWithFormat:@"Error in closing '%@'", _fileName];
-				@throw [[[ZipException alloc] initWithError:err reason:reason] autorelease];
+				@throw [[ZipException alloc] initWithError:err reason:reason];
 			}
 			break;
 		}
@@ -432,7 +429,7 @@
 			int err= zipClose(_zipFile, NULL);
 			if (err != ZIP_OK) {
 				NSString *reason= [NSString stringWithFormat:@"Error in closing '%@'", _fileName];
-				@throw [[[ZipException alloc] initWithError:err reason:reason] autorelease];
+				@throw [[ZipException alloc] initWithError:err reason:reason];
 			}
 			break;
 		}
@@ -441,14 +438,14 @@
 			int err= zipClose(_zipFile, NULL);
 			if (err != ZIP_OK) {
 				NSString *reason= [NSString stringWithFormat:@"Error in closing '%@'", _fileName];
-				@throw [[[ZipException alloc] initWithError:err reason:reason] autorelease];
+				@throw [[ZipException alloc] initWithError:err reason:reason];
 			}
 			break;
 		}
 
 		default: {
 			NSString *reason= [NSString stringWithFormat:@"Unknown mode %d", _mode];
-			@throw [[[ZipException alloc] initWithReason:reason] autorelease];
+			@throw [[ZipException alloc] initWithReason:reason];
 		}
 	}
 }

--- a/Objective-Zip/ZipFile.m
+++ b/Objective-Zip/ZipFile.m
@@ -37,7 +37,7 @@
 #import "ZipWriteStream.h"
 #import "FIleInZipInfo.h"
 
-#define FILE_IN_ZIP_MAX_NAME_LENGTH (256)
+#define FILE_IN_ZIP_MAX_NAME_LENGTH (512)
 
 @implementation ZipFile
 

--- a/Objective-Zip/ZipFile.m
+++ b/Objective-Zip/ZipFile.m
@@ -60,7 +60,7 @@
                 NSMutableDictionary* dic = [NSMutableDictionary dictionary];
                 
                 do {
-                    FileInZipInfo* info = [self getCurrentFileInZipInfo];
+                    FileInZipInfo* info = [self currentFileInZipInfo];
                     unz_file_pos pos;
                     int err = unzGetFilePos(_unzFile, &pos);
                     if (err == UNZ_OK) {
@@ -241,7 +241,7 @@
 
 	[self goToFirstFileInZip];
 	for (int i= 0; i < num; i++) {
-		FileInZipInfo *info= [self getCurrentFileInZipInfo];
+		FileInZipInfo *info= [self currentFileInZipInfo];
 		[files addObject:info];
 
 		if ((i +1) < num)
@@ -311,7 +311,7 @@
 	return YES;
 }
 
-- (FileInZipInfo *) getCurrentFileInZipInfo {
+- (FileInZipInfo *)currentFileInZipInfo {
 	if (_mode != ZipFileModeUnzip) {
 		NSString *reason= [NSString stringWithFormat:@"Operation not permitted without Unzip mode"];
 		@throw [[[ZipException alloc] initWithReason:reason] autorelease];

--- a/Objective-Zip/ZipReadStream.m
+++ b/Objective-Zip/ZipReadStream.m
@@ -54,7 +54,7 @@
 	int bytes = unzReadCurrentFile(_unzFile, [data mutableBytes], (unsigned)length);
 	if (bytes < 0) {
 		NSString *reason= [NSString stringWithFormat:@"Error in reading '%@' in the zipfile", _fileNameInZip];
-		@throw [[[ZipException alloc] initWithError:bytes reason:reason] autorelease];
+		@throw [[ZipException alloc] initWithError:bytes reason:reason];
 	}
 	
 	[data setLength:bytes];
@@ -65,7 +65,7 @@
 	int err= unzCloseCurrentFile(_unzFile);
 	if (err != UNZ_OK) {
 		NSString *reason= [NSString stringWithFormat:@"Error in closing '%@' in the zipfile", _fileNameInZip];
-		@throw [[[ZipException alloc] initWithError:err reason:reason] autorelease];
+		@throw [[ZipException alloc] initWithError:err reason:reason];
 	}
 }
 

--- a/Objective-Zip/ZipWriteStream.h
+++ b/Objective-Zip/ZipWriteStream.h
@@ -45,6 +45,7 @@
 
 - (id) initWithZipFileStruct:(zipFile)zipFile fileNameInZip:(NSString *)fileNameInZip;
 
+- (void) writeBytes:(const void *)bytes length:(unsigned int)length;
 - (void) writeData:(NSData *)data;
 - (void) finishedWriting;
 

--- a/Objective-Zip/ZipWriteStream.m
+++ b/Objective-Zip/ZipWriteStream.m
@@ -53,7 +53,7 @@
 	int err= zipWriteInFileInZip(_zipFile, bytes, length);
 	if (err < 0) {
 		NSString *reason= [NSString stringWithFormat:@"Error in writing '%@' in the zipfile", _fileNameInZip];
-		@throw [[[ZipException alloc] initWithError:err reason:reason] autorelease];
+		@throw [[ZipException alloc] initWithError:err reason:reason];
 	}
 }
 
@@ -65,7 +65,7 @@
 	int err= zipCloseFileInZip(_zipFile);
 	if (err != ZIP_OK) {
 		NSString *reason= [NSString stringWithFormat:@"Error in closing '%@' in the zipfile", _fileNameInZip];
-		@throw [[[ZipException alloc] initWithError:err reason:reason] autorelease];
+		@throw [[ZipException alloc] initWithError:err reason:reason];
 	}
 }
 

--- a/Objective-Zip/ZipWriteStream.m
+++ b/Objective-Zip/ZipWriteStream.m
@@ -49,12 +49,16 @@
 	return self;
 }
 
-- (void) writeData:(NSData *)data {
-	int err= zipWriteInFileInZip(_zipFile, [data bytes], (unsigned)[data length]);
+- (void) writeBytes:(const void *)bytes length:(unsigned int)length {
+	int err= zipWriteInFileInZip(_zipFile, bytes, length);
 	if (err < 0) {
 		NSString *reason= [NSString stringWithFormat:@"Error in writing '%@' in the zipfile", _fileNameInZip];
 		@throw [[[ZipException alloc] initWithError:err reason:reason] autorelease];
 	}
+}
+
+- (void) writeData:(NSData *)data {
+    [self writeBytes:data.bytes length:(unsigned int)data.length];
 }
 
 - (void) finishedWriting {


### PR DESCRIPTION
There is a subtle issue in ZipFile.m with how the file contents dictionary is parsed for -initWithFileName:mode: and then queried in -locateFileInZip: . If -locateFileInZip: is called with a string that uses a different Unicode normalization form than what was used to encode the file names and used as the key in the contents dictionary, the file info object is not found (the ZipFile 'contents' dictionary would have its keys in a different Unicode normalisation form).

To give an example, here are two strings which look exactly similar to the eye but have different hash codes (and therefore different keys in an NSDictionary):

(gdb) print (NSUInteger)[@"Contents/Resources/N. Engl. J. Med. 2009 Hütter.pdf" hash]
$5 = 523423533613971934
(gdb) print (NSUInteger)[@"Contents/Resources/N. Engl. J. Med. 2009 Hütter.pdf" hash]
$6 = 13774458812937735516

In an error case I encountered, the string I received from another component in the application uses the 2nd kind of representation, whereas Objective-Zip the first kind. Requiring a certain Unicode normalization form as arguments given to -locateFileInZip: is not practical, therefore my suggested solution uses uses the Normalization Form D as the 'contents' dictionary keys (the file info 'name' strings), and converts the string given as an argument to -locateFileInZip: to this same form.
